### PR TITLE
badblocks_check takes sector_t *bad_sectors

### DIFF
--- a/md.h
+++ b/md.h
@@ -210,7 +210,7 @@ enum flag_bits {
 };
 
 static inline int is_badblock(struct md_rdev *rdev, sector_t s, int sectors,
-			      sector_t *first_bad, int *bad_sectors)
+			      sector_t *first_bad, sector_t *bad_sectors)
 {
 	if (unlikely(rdev->badblocks.count)) {
 		int rv = badblocks_check(&rdev->badblocks, rdev->data_offset + s,


### PR DESCRIPTION
Signatures in kernel include/linux/badblocks.h changed for block/badblocks.c:badblocks_check: `int *bad_sectors` now `sector_t *bad_sectors`.

Change occurred in https://github.com/torvalds/linux/commit/d301f164c3fbff611bd71f57dfa553b9219f0f

> This change avoids truncation of badblocks length for large sectors by
> replacing 'int' with 'sector_t' (u64), enabling proper handling of larger
> disk sizes and ensuring compatibility with 64-bit sector addressing.